### PR TITLE
Disclaimer to top of ERP X page

### DIFF
--- a/_hack-for-public-good-2024/2024 Projects/ERP X.md
+++ b/_hack-for-public-good-2024/2024 Projects/ERP X.md
@@ -6,6 +6,9 @@ description: ""
 third_nav_title: 2024 Projects
 ---
 <h3>ERP X</h3>
+<p><em>This is a Hackathon project for Open Government Product's Hack for Public Good 2024 (HFPG). HFPG projects can be implemented as pilots made available only for trial and feedback purposes.</em>
+</p>
+<p></p>
 <div class="iframe-wrapper">
 <iframe height="315" width="100%" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/LTLgmK-xdDg?si=BSIc3IRW8GRMOKFB"></iframe>
 </div>


### PR DESCRIPTION
Added the following disclaimer to the top of the ERP X page:

"This is a Hackathon project for Open Government Product's Hack for Public Good 2024 (HFPG). HFPG projects can be implemented as pilots made available only for trial and feedback purposes."